### PR TITLE
Update the copy of examples in libraries/LINX/examples.

### DIFF
--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/libraries/LINX/examples/ESP8266_Wifi_Configurable/ESP8266_Wifi_Configurable.ino
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/libraries/LINX/examples/ESP8266_Wifi_Configurable/ESP8266_Wifi_Configurable.ino
@@ -1,0 +1,47 @@
+/****************************************************************************************	
+**  This is example LINX firmware for use with the ESP8266
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Ken Sharp
+**
+**  BSD2 License.
+****************************************************************************************/
+
+//Include All Peripheral Libraries Used By LINX
+#include <SPI.h>
+#include <Wire.h>
+#include <EEPROM.h>
+#include <Servo.h>
+#include <ESP8266WiFi.h>
+
+//Include Device Specific Header From Sketch>>Import Library (In This Case LinxChipkitMax32.h)
+//Also Include Desired LINX Listener From Sketch>>Import Library 
+#include <LinxESP8266.h>
+#include <LinxESP8266WifiListener.h>
+ 
+//Create A Pointer To The LINX Device Object We Instantiate In Setup()
+LinxESP8266* LinxDevice;
+
+//Initialize LINX Device And Listener
+void setup()
+{
+  //Instantiate The LINX Device
+  LinxDevice = new LinxESP8266();
+  
+  //The LINX Serial Listener Is Included In WIFI Listener And Pre Instantiated.  This Is Necessary For Configuring Wifi Settings.
+  LinxSerialConnection.Start(LinxDevice, 0);
+  
+  //Start Wifi Listener.  Settings (IP, SSID, etc) Will Be Read From Non Volatile Storage And Can Be Set Using LINX VIs Via USB
+  LinxWifiConnection.Start(LinxDevice);
+}
+
+void loop()
+{
+  //Listen For New Packets From LabVIEW
+  LinxWifiConnection.CheckForCommands();
+  LinxSerialConnection.CheckForCommands();
+  
+  //Your Code Here, But It will Slow Down The Connection With LabVIEW
+}

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/libraries/LINX/examples/ESP8266_Wifi_Static_Configuration/ESP8266_Wifi_Static_Configuration.ino
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/libraries/LINX/examples/ESP8266_Wifi_Static_Configuration/ESP8266_Wifi_Static_Configuration.ino
@@ -1,11 +1,10 @@
 /****************************************************************************************	
-**  This is example LINX firmware for use with the chipKIT WF32 with the WIFI
-**  interface enabled.
+**  This is example LINX firmware for use with the ESP8266 device
 **
 **  For more information see:           www.labviewmakerhub.com/linx
 **  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
-**  
-**  Written By Sam Kristoff
+**
+**  Written By Ken Sharp
 **
 **  BSD2 license.
 ****************************************************************************************/
@@ -15,34 +14,27 @@
 #include <Wire.h>
 #include <EEPROM.h>
 #include <Servo.h>
-#include <WS2812.h>
+#include <ESP8266WiFi.h>
 
-#include <MRF24G.h>
-#include <DEIPcK.h>
-#include <DEWFcK.h>
-
-//Include Device Specific Header From Sketch>>Import Library (In This Case LinxChipkitMax32.h)
-//Also Include Desired LINX Listener From Sketch>>Import Library (In This Case LinxSerialListener.h)
-#include <LinxChipkitWf32.h>
-#include <LinxChipkitWifiListener.h>
+//Include Device Specific Header From Sketch>>Import Library (In This Case LinxESP8266.h)
+//Also Include Desired LINX Listener From Sketch>>Import Library (In This Case LinxESP8266WifiListener.h)
+#include <LinxESP8266.h>
+#include <LinxESP8266WifiListener.h>
  
 //Create A Pointer To The LINX Device Object We Instantiate In Setup()
-LinxChipkitWf32* LinxDevice;
+LinxESP8266* LinxDevice;
 
 //Initialize LINX Device And Listener
 void setup()
 {
   //Instantiate The LINX Device
-  LinxDevice = new LinxChipkitWf32();
-  
-   //The LINX Serial Listener Is Included In WIFI Listener And Pre Instantiated.
-  LinxSerialConnection.Start(LinxDevice, 0);  
-  
+  LinxDevice = new LinxESP8266();
+   
   //The LINX Listener Is Pre Instantiated.  
   //Set SSID (Network Name), Security Type, Passphrase/Key, And Call Start With Desired Device IP and Port
   LinxWifiConnection.SetSsid("YOUR_NETWORK_NAME");
-  LinxWifiConnection.SetSecurity(WPA2_PASSPHRASE);    		   //NONE, WPA2_PASSPHRASE, WPA2_KEY, WEP40, WEO104
-  LinxWifiConnection.SetPassphrase("PASSPHRASE");    			   //NONE, WPA2_PASSPHRASE, WPA2_KEY, WEP40, WEO104
+  LinxWifiConnection.SetSecurity(WPA2_PASSPHRASE);  //NONE, WPA2_PASSPHRASE, WPA2_KEY, WEP40, WEO104
+  LinxWifiConnection.SetPassphrase("PASSPHRASE");    			   
   LinxWifiConnection.Start(LinxDevice, 192, 168, 1, 128, 44300);  //Start With Fixed IP and Port.  When Using This Method You Cannot Update The IP/Port Using LINX VIs
 }
 
@@ -53,5 +45,3 @@ void loop()
   
   //Your Code Here, But It will Slow Down The Connection With LabVIEW
 }
-
-


### PR DESCRIPTION
Update the copy of examples in libraries/LINX/examples to match
core/examples. (It was out of sync with commit e370d98b673).

Perhaps we should just remove these redundant files from git (needed only because
Arduino tools require a flat library hierarchy), add a makefile
rule to copy them here when building Arduino targets, and add the files
in this location to a .gitignore.