### PR TITLE
Fix UART on RPi3 and RPi4

### DIFF
--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.cpp
@@ -55,7 +55,7 @@ unsigned char LinxRaspberryPi2B::m_I2cRefCount[NUM_I2C_CHANS];
 //UART
 unsigned char LinxRaspberryPi2B::m_UartChans[NUM_UART_CHANS] = {0};
 int LinxRaspberryPi2B::m_UartHandles[NUM_UART_CHANS];
-string LinxRaspberryPi2B::m_UartPaths[NUM_UART_CHANS] = {"/dev/ttyAMA0"};
+string LinxRaspberryPi2B::m_UartPaths[NUM_UART_CHANS] = {"/dev/serial0"};
 unsigned long LinxRaspberryPi2B::m_UartSupportedSpeeds[NUM_UART_SPEEDS] = {0, 50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600, 19200, 38400, 57600, 115200};
 unsigned long LinxRaspberryPi2B::m_UartSupportedSpeedsCodes[NUM_UART_SPEEDS] = {B0, B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200, B38400, B57600, B115200};
 


### PR DESCRIPTION
The LINX UART implementation uses /dev/ttyAMA0.  This works on RPi2 but for RPi3 and 4 they repurposed that port and the UART pins map to /dev/ttyS0.

The RPi folks already saw this as an issue so now there is a symlink that always points to the correct serial device (/dev/serial0).  Change the LINX implementation to use the symlink.