### PR TITLE
Add support for Raspberry Pi 5

### DIFF
--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.cpp
@@ -1,0 +1,234 @@
+/****************************************************************************************
+**  LINX Raspberry Pi 2 Model B Code
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Sam Kristoff
+**
+** BSD2 License.
+****************************************************************************************/	
+
+/****************************************************************************************
+**  Includes
+****************************************************************************************/		
+#include <termios.h>
+#include <unistd.h>
+
+#include "utility/LinxDevice.h"
+#include "utility/LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+
+/****************************************************************************************
+**  Member Variables
+****************************************************************************************/
+//System
+const unsigned char LinxRaspberryPi5::m_DeviceName[DEVICE_NAME_LEN] = "Raspberry Pi 5";
+
+//AI
+//None 
+
+//AO
+//None
+
+//DIGITAL
+const unsigned char LinxRaspberryPi5::m_DigitalChans[NUM_DIGITAL_CHANS] = {7, 11, 12, 13, 15, 16, 18, 22, 29, 31, 32, 33, 35, 36, 37, 38, 40};
+const unsigned int LinxRaspberryPi5::m_gpioChan[NUM_DIGITAL_CHANS] =     {403, 416, 417, 426, 421, 422, 423, 424, 404, 405, 411, 412, 418, 415, 425, 419, 420};
+
+//PWM
+//None
+
+//QE
+//None
+
+//SPI
+const unsigned char LinxRaspberryPi5::m_SpiChans[NUM_SPI_CHANS] = {0};
+string m_SpiPaths[NUM_SPI_CHANS] = { "/dev/spidev0.1"};
+unsigned long LinxRaspberryPi5::m_SpiSupportedSpeeds[NUM_SPI_SPEEDS] = {7629, 15200, 30500, 61000, 122000, 244000, 488000, 976000, 1953000, 3900000, 7800000, 15600000, 31200000};
+int LinxRaspberryPi5::m_SpiSpeedCodes[NUM_SPI_SPEEDS] = {7629, 15200, 30500, 61000, 122000, 244000, 488000, 976000, 1953000, 3900000, 7800000, 15600000, 31200000};
+
+//I2C
+unsigned char LinxRaspberryPi5::m_I2cChans[NUM_I2C_CHANS] = {1};
+string m_I2cPaths[NUM_I2C_CHANS] = {"/dev/i2c-1"};
+unsigned char LinxRaspberryPi5::m_I2cRefCount[NUM_I2C_CHANS];
+
+//UART
+unsigned char LinxRaspberryPi5::m_UartChans[NUM_UART_CHANS] = {0};
+int LinxRaspberryPi5::m_UartHandles[NUM_UART_CHANS];
+string LinxRaspberryPi5::m_UartPaths[NUM_UART_CHANS] = {"/dev/serial0"};
+unsigned long LinxRaspberryPi5::m_UartSupportedSpeeds[NUM_UART_SPEEDS] = {0, 50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800, 9600, 19200, 38400, 57600, 115200};
+unsigned long LinxRaspberryPi5::m_UartSupportedSpeedsCodes[NUM_UART_SPEEDS] = {B0, B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200, B38400, B57600, B115200};
+
+//SERVO
+//None
+
+/****************************************************************************************
+**  Constructors /  Destructor
+****************************************************************************************/
+LinxRaspberryPi5::LinxRaspberryPi5()
+{
+	DeviceFamily = 0x04;	//Raspberry Pi Family Code
+	DeviceId = 0x05;			//Raspberry Pi 5
+	DeviceNameLen = DEVICE_NAME_LEN;	 
+	DeviceName =  m_DeviceName;
+
+	//LINX API Version
+	LinxApiMajor = 2;
+	LinxApiMinor = 2;
+	LinxApiSubminor = 0;
+	
+	//DIGITAL
+	NumDigitalChans = NUM_DIGITAL_CHANS;			
+	DigitalChans = m_DigitalChans;
+		
+	//AI
+	NumAiChans = NUM_AI_CHANS;
+	AiChans = 0;
+	AiResolution = 0;
+	AiRefSet = 0;
+		
+	AiRefDefault = AI_REFV;
+	AiRefSet = AI_REFV;
+	AiRefCodes = NULL;
+	
+	NumAiRefIntVals = NUM_AI_INT_REFS;
+	AiRefIntVals = NULL;
+	
+	AiRefExtMin = 0;
+	AiRefExtMax = 0;
+	
+	//AO
+	NumAoChans = 0;
+	AoChans = 0;
+	AoResolution = 0;
+    AoRefDefault = 0;
+	AoRefSet = 0;
+	
+	//PWM
+	NumPwmChans = NUM_PWM_CHANS;
+	PwmChans = 0;
+	
+	//QE
+	NumQeChans = 0;
+	QeChans = 0;
+		
+	//UART
+	NumUartChans = NUM_UART_CHANS;
+	UartChans = m_UartChans;	
+	UartMaxBaud = m_UartSupportedSpeeds[NUM_UART_SPEEDS - 1];
+	NumUartSpeeds = NUM_UART_SPEEDS;
+	UartSupportedSpeeds = m_UartSupportedSpeeds;
+	UartSupportedSpeedsCodes = m_UartSupportedSpeedsCodes;
+	
+	//I2C
+	NumI2cChans = NUM_I2C_CHANS;	
+	I2cChans = m_I2cChans;
+	I2cRefCount = m_I2cRefCount;
+		
+	//SPI
+	NumSpiChans = NUM_SPI_CHANS;	
+	SpiChans = m_SpiChans;		
+	NumSpiSpeeds = NUM_SPI_SPEEDS;
+	SpiSupportedSpeeds = m_SpiSupportedSpeeds;
+	SpiSpeedCodes = m_SpiSpeedCodes;
+		
+	//CAN
+	NumCanChans = NUM_CAN_CHANS;
+	CanChans = 0;
+	
+	//Servo 
+	NumServoChans = NUM_SERVO_CHANS;
+	ServoChans = 0;
+			
+	//------------------------------------- Digital -------------------------------------
+	//Export GPIO - Set All Digital Handles To NULL
+	for(int i=0; i<NUM_DIGITAL_CHANS; i++)
+	{
+		FILE* digitalExportHandle = fopen("/sys/class/gpio/export", "w");
+		fprintf(digitalExportHandle, "%d", m_gpioChan[i]);
+		fclose(digitalExportHandle);
+		
+		DigitalDirHandles[m_DigitalChans[i]] = NULL;
+		DigitalValueHandles[m_DigitalChans[i]] = NULL;
+		DigitalChannels[m_DigitalChans[i]] = m_gpioChan[i];
+		DigitalDirs[m_DigitalChans[i]] = INPUT;
+	}
+	
+	//------------------------------------- I2C -------------------------------------
+	//Store I2C Master Paths In Map
+	for(int i=0; i<NUM_I2C_CHANS; i++)
+	{	
+		I2cPaths[I2cChans[i]] = m_I2cPaths[i];
+	}
+	
+	//------------------------------------- SPI -------------------------------------
+	//Load SPI Paths And Configure SPI Master Default Values	
+	SpiDefaultSpeed = 3900000;
+	for(int i=0; i<NUM_SPI_CHANS; i++)
+	{				
+		SpiBitOrders[SpiChans[i]] = MSBFIRST;		//MSB First
+		SpiSetSpeeds[SpiChans[i]] = SpiDefaultSpeed;
+		SpiPaths[SpiChans[i]] = m_SpiPaths[i];
+	}
+	
+	//------------------------------------- UART -------------------------------------
+	for(int i=0; i<NUM_UART_CHANS; i++)
+	{
+		UartPaths[m_UartChans[i]] = m_UartPaths[i];
+		UartHandles[m_UartChans[i]] = 0;
+	}	
+	
+	//If Debuging Is Enabled Call EnableDebug()
+	#if DEBUG_ENABLED > -1
+		EnableDebug(DEBUG_ENABLED);
+	#endif
+}
+
+//Destructor
+LinxRaspberryPi5::~LinxRaspberryPi5()
+{	
+	//Close GPIO Handles If They Are Open
+	for(int i=0; i<NUM_DIGITAL_CHANS; i++)
+	{
+		if(DigitalDirHandles[m_DigitalChans[i]] != NULL)
+		{			
+			fclose(DigitalDirHandles[m_DigitalChans[i]]);
+		}
+		if(DigitalValueHandles[m_DigitalChans[i]] != NULL)
+		{			
+			fclose(DigitalValueHandles[m_DigitalChans[i]]);
+		}
+	}
+	
+	//Close I2C Handles
+	for(int i=0; i<NUM_I2C_CHANS; i++)
+	{
+		if(I2cHandles[m_I2cChans[i]] != 0)
+		{	
+			close(I2cHandles[m_I2cChans[i]]);
+		}
+	}
+	
+	//Close SPI Handles
+	for(int i=0; i<NUM_SPI_CHANS; i++)
+	{
+		if(SpiHandles[m_SpiChans[i]] != 0)
+		{	
+			close(SpiHandles[m_SpiChans[i]]);
+		}
+	}
+	
+	//Close UART Handles
+	for(int i=0; i<NUM_UART_CHANS; i++)
+	{
+		if(UartHandles[m_UartChans[i]] != 0)
+		{	
+			close(UartHandles[m_UartChans[i]]);
+		}
+	}	
+}
+
+/****************************************************************************************
+**  Functions
+****************************************************************************************/
+

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.cpp
@@ -1,10 +1,10 @@
 /****************************************************************************************
-**  LINX Raspberry Pi 2 Model B Code
+**  LINX Raspberry Pi 5 Code
 **
 **  For more information see:           www.labviewmakerhub.com/linx
 **  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
 **  
-**  Written By Sam Kristoff
+**  Written By Ken Sharp
 **
 ** BSD2 License.
 ****************************************************************************************/	

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.h
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.h
@@ -1,0 +1,118 @@
+/****************************************************************************************
+**  LINX header for Raspberry Pi 5
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Ken Sharp
+**
+** BSD2 License.
+****************************************************************************************/	
+
+#ifndef LINX_RASPBERRYPI2B_H
+#define LINX_RASPBERRYPI2B_H
+
+/****************************************************************************************
+**  Defines
+****************************************************************************************/	
+#define DEVICE_NAME_LEN 23
+
+#define NUM_AI_CHANS 0
+#define AI_RES_BITS 0
+#define AI_REFV 0
+#define NUM_AI_INT_REFS 0
+
+#define NUM_CAN_CHANS 0
+
+#define NUM_DIGITAL_CHANS 17
+
+#define NUM_PWM_CHANS 0
+
+#define NUM_SPI_CHANS 1
+#define NUM_SPI_SPEEDS 13
+
+#define NUM_I2C_CHANS 1
+
+#define NUM_UART_CHANS 1
+#define NUM_UART_SPEEDS 18
+
+#define NUM_SERVO_CHANS 0
+
+/****************************************************************************************
+**  Includes
+****************************************************************************************/	
+#include "utility/LinxDevice.h"
+#include "utility/LinxRaspberryPi.h"
+#include <string>
+#include <map>
+
+using namespace std;
+	
+class LinxRaspberryPi5 : public LinxRaspberryPi
+{
+	public:	
+		/****************************************************************************************
+		**  Variables
+		****************************************************************************************/		
+		//System
+		static const unsigned char m_DeviceName[DEVICE_NAME_LEN];
+		
+		//AI		
+		//None
+		
+		//AO
+		//None
+		
+		//CAN
+		//None
+		
+		//DIGITAL
+		static const unsigned char m_DigitalChans[NUM_DIGITAL_CHANS];
+		static const unsigned char m_gpioChan[NUM_DIGITAL_CHANS];
+		
+		//PWM
+		//None
+		
+		//SPI
+		static const unsigned char m_SpiChans[NUM_SPI_CHANS];
+		static int m_SpiHandles[NUM_SPI_CHANS];
+		static unsigned long m_SpiSupportedSpeeds[NUM_SPI_SPEEDS];
+		static int m_SpiSpeedCodes[NUM_SPI_SPEEDS];
+				
+		//I2C
+		static unsigned char m_I2cChans[NUM_I2C_CHANS];
+		static unsigned char m_I2cRefCount[NUM_I2C_CHANS];		
+		
+		//UART
+		static unsigned char m_UartChans[NUM_UART_CHANS];
+		static unsigned long m_UartSupportedSpeeds[NUM_UART_SPEEDS];
+		static unsigned long m_UartSupportedSpeedsCodes[NUM_UART_SPEEDS];
+		static int m_UartHandles[NUM_UART_CHANS];
+		static string m_UartPaths[NUM_UART_CHANS];
+
+		
+		//Servo		
+		//None
+		
+		/****************************************************************************************
+		**  Constructors /  Destructor
+		****************************************************************************************/
+		LinxRaspberryPi5();
+		virtual ~LinxRaspberryPi5();
+		
+		/****************************************************************************************
+		**  Functions
+		****************************************************************************************/
+				
+	private:
+		/****************************************************************************************
+		**  Variables
+		****************************************************************************************/		
+				
+		/****************************************************************************************
+		**  Functions
+		****************************************************************************************/
+				
+};
+
+#endif //LINX_RASPBERRYPI2B

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.h
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi5.h
@@ -9,8 +9,8 @@
 ** BSD2 License.
 ****************************************************************************************/	
 
-#ifndef LINX_RASPBERRYPI2B_H
-#define LINX_RASPBERRYPI2B_H
+#ifndef LINX_RASPBERRYPI5_H
+#define LINX_RASPBERRYPI5_H
 
 /****************************************************************************************
 **  Defines
@@ -115,4 +115,4 @@ class LinxRaspberryPi5 : public LinxRaspberryPi
 				
 };
 
-#endif //LINX_RASPBERRYPI2B
+#endif //LINX_RASPBERRYPI5

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/LinxDeviceLib/src/LinxDeviceLib.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/LinxDeviceLib/src/LinxDeviceLib.cpp
@@ -21,6 +21,10 @@
 			#define LINXDEVICETYPE LinxRaspberryPi2B
 			#include "LinxRaspberryPi.h"
 			#include "LinxRaspberryPi2B.h"
+	#elif LINX_DEVICE_ID == 5	//RPI 5
+			#define LINXDEVICETYPE LinxRaspberryPi5
+			#include "LinxRaspberryPi.h"
+			#include "LinxRaspberryPi5.h"
 	#endif
 //------------------------------------- Beagle Bone -------------------------------------
 #elif LINX_DEVICE_FAMILY == 6	

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Configurable/src/RaspberryPi_5_Configurable.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Configurable/src/RaspberryPi_5_Configurable.cpp
@@ -1,0 +1,186 @@
+/****************************************************************************************
+**  LINX Configurable Listener For Raspberry Pi 5
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Ken Sharp
+**
+** BSD2 License.
+****************************************************************************************/	
+
+#include <stdio.h>
+#include <iostream>
+#include <string>
+#include <stdlib.h> 
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+#include "LinxSerialListener.h"
+#include "LinxLinuxTcpListener.h"
+
+//Helper Functions
+int parseInputTokens(LinxDevice* linxDev, int argc, char* argv[]);
+void printUsage(char* argv[], LinxDevice* linxDev);
+
+#define NUMTOKENS 10
+string tokens[NUMTOKENS] = {"-h", "-H", "--help", "--Help", "-v", "-V", "--version", "--Version", "-serial", "-tcp"};
+
+int uartListenerPort = -1;
+int tcpListenerPort = -1;
+
+LinxRaspberryPi5* LinxDev;
+
+int main(int argc, char* argv[])
+{
+	
+
+	//Instantiate The LINX Device
+	LinxDev = new LinxRaspberryPi5();
+	
+	if(parseInputTokens(LinxDev, argc, argv) >= 0)
+	{	
+		if(uartListenerPort > -1 && tcpListenerPort > -1)
+		{
+			while(1)
+			{
+				LinxSerialConnection.CheckForCommands();
+				LinxTcpConnection.CheckForCommands();
+			}
+		}
+		else if(uartListenerPort > -1)
+		{
+			while(1)
+			{
+				LinxSerialConnection.CheckForCommands();
+			}
+			
+		}
+		else if(tcpListenerPort > -1)
+		{
+			while(1)
+			{
+				LinxTcpConnection.CheckForCommands();
+			}
+		}
+		else
+		{
+			cout << "No bus specified.\n";
+			printUsage(argv, LinxDev);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+
+//Helper function to parse input tokens and set variables or print output.
+int parseInputTokens(LinxDevice* linxDev, int argc, char* argv[])
+{
+	cout << "\n";
+	
+	//Loop Over All Tokens
+	for(int i=1; i<argc; i++)
+	{
+		//cout << argv[i];
+		
+		bool match = false;
+		for(int j=0; j<NUMTOKENS; j++)
+		{
+			if(tokens[j].compare(argv[i]) == 0)
+			{
+				//cout << " - match\n";
+				match = true;
+				
+				switch(j)
+				{
+					case 0: 	//-h
+					case 1: 	//-H
+					case 2:	//--help
+					case 3: 	//--Help
+						printUsage(argv, linxDev);
+						return 0;
+					case 4: 	//-v
+					case 5: 	//-V
+					case 6:	//--version
+					case 7: 	//--Version
+						cout << "\n"<< argv[0] << " version 2.1.0\n";
+						return 0;
+					case 8:	//-serial
+						if(i+1 >= argc)
+						{
+							cout << "\n"<< "Missing port\n";
+							printUsage(argv, linxDev);
+							return -1;
+						}
+						else
+						{
+							uartListenerPort = atoi(argv[i+1]);
+							bool validPort = false;
+							
+							for(int i=0; i<linxDev->NumUartChans; i++)
+							{
+								if(uartListenerPort == linxDev->UartChans[i])
+								{	
+									cout << "\n\n ..:: LINX ::..\n\n";
+									cout << "Listening on UART " << (unsigned short)uartListenerPort << "\n";
+									LinxSerialConnection.Start(LinxDev, (unsigned char)uartListenerPort);
+									validPort = true;
+									break;
+								}
+							}
+							if(!validPort)
+							{
+								//Invalid Port, Print Usage
+								cout << "Invalid port.\n";
+								printUsage(argv, linxDev);
+								return -1;
+							}
+							break;
+						}
+						break;
+					case 9:	//-tcp
+						if(i+1 >= argc)
+						{
+							cout << "\n"<< "Missing port\n";
+							printUsage(argv, linxDev);
+							return -1;
+						}
+						else
+						{
+							tcpListenerPort = atoi(argv[i+1]);
+							cout << "\n\n ..:: LINX ::..\n\n";
+							cout << "Listening on TCP Port " << (unsigned short)tcpListenerPort << "\n";
+							LinxTcpConnection.Start(LinxDev, tcpListenerPort);
+						}
+						break;
+					default:
+						break;
+				}
+			}
+		}
+		if(!match)
+		{
+			//Either Argument or invalid token
+		}
+		
+	}
+	return 0;
+}
+
+//Helper function to print usage information.
+void printUsage(char* argv[], LinxDevice* linxDev)
+{
+	cout << "\nusage: " << argv[0] << " -serial [port]\n";
+	cout << "   or: " << argv[0] << " -serial [port] -tcp [port]\n";
+	cout << "   or: " << argv[0] << " -tcp [port]\n\n";
+	cout << "Available options are:\n";
+	cout << "  -serial\t " << (int)linxDev->UartChans[0];
+	for(int i = 1; i<linxDev->NumUartChans; i++)
+	{
+		cout << ", " << (int)linxDev->UartChans[i];
+	}	
+	cout << "\n";
+	cout << "  -tcp  \t Any valid, unused TCP port. (ex 44300)\n\n";
+}

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Serial/src/RaspberryPi_5_Serial.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Serial/src/RaspberryPi_5_Serial.cpp
@@ -1,0 +1,44 @@
+/****************************************************************************************
+**  LINX Serial Listener For Raspberry Pi 5
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Ken Sharp
+**
+** BSD2 License.
+****************************************************************************************/	
+
+#include <stdio.h>
+#include <iostream>
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+#include "LinxSerialListener.h"
+
+#define LISTENER_UART_PORT 0
+
+LinxRaspberryPi5* LinxDevice;
+
+
+int main()
+{
+	fprintf(stdout, "\n\n ..:: LINX ::..\n\n");
+	
+	//Instantiate The LINX Device
+	LinxDevice = new LinxRaspberryPi5();
+	
+	//The LINXT Listener Is Pre Instantiated, Call Start And Pass A Pointer To The LINX Device And The UART Channel To Listen On
+	LinxSerialConnection.Start(LinxDevice, LISTENER_UART_PORT);
+
+	fprintf(stdout, "Listening On UART %d.\n", LISTENER_UART_PORT);
+
+	//Check for and process commands
+	while(1)
+	{
+		LinxSerialConnection.CheckForCommands();
+	}
+
+	return 0;
+}

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Tcp/src/RaspberryPi_5_Tcp.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/examples/RaspberryPi_5_Tcp/src/RaspberryPi_5_Tcp.cpp
@@ -1,0 +1,43 @@
+/****************************************************************************************
+**  LINX TCP Listener For Raspberry Pi 5
+**
+**  For more information see:           www.labviewmakerhub.com/linx
+**  For support visit the forums at:    www.labviewmakerhub.com/forums/linx
+**  
+**  Written By Ken Sharp
+**
+** BSD2 License.
+****************************************************************************************/	
+
+#include <stdio.h>
+#include <iostream>
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+#include "LinxLinuxTcpListener.h"
+
+#define LISTENER_TCP_PORT 44300
+
+LinxRaspberryPi5* LinxDev;
+
+int main()
+{
+	fprintf(stdout, "\n\n ..:: LINX ::..\n\n");
+	
+	//Instantiate The LINX Device
+	LinxDev = new LinxRaspberryPi5();
+	
+	//The LINXT Listener Is Pre Instantiated, Call Start And Pass A Pointer To The LINX Device And The UART Channel To Listen On
+	LinxTcpConnection.Start(LinxDev, LISTENER_TCP_PORT);
+
+	fprintf(stdout, "Listening On TCP Port %d.\n", LISTENER_TCP_PORT);
+	
+	//Check for and process commands
+	while(1)
+	{
+		LinxTcpConnection.CheckForCommands();
+	}
+
+	return 0;
+}

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/make/Makefile
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/make/Makefile
@@ -5,6 +5,7 @@ INC=-I../core/device/utility -I../core/device/ -I../core/listener
 CORE_LINX=../core/device/utility/LinxDevice.cpp
 CORE_LISTENER=../core/listener/utility/LinxListener.cpp
 CORE_RPI2=$(CORE_LINX) ../core/device/utility/LinxRaspberryPi.cpp ../core/device/LinxRaspberryPi2B.cpp
+CORE_RPI5=$(CORE_LINX) ../core/device/utility/LinxRaspberryPi.cpp ../core/device/LinxRaspberryPi5.cpp
 CORE_BBB=$(CORE_LINX) ../core/device/utility/LinxBeagleBone.cpp ../core/device/LinxBeagleBoneBlack.cpp
 
 LISTENER_SERIAL=$(CORE_LISTENER) ../core/listener/LinxSerialListener.cpp
@@ -12,20 +13,26 @@ LISTENER_TCP=$(CORE_LISTENER) ../core/listener/LinxLinuxTcpListener.cpp
 LISTENER_CONFIG=$(CORE_LISTENER) ../core/listener/LinxSerialListener.cpp ../core/listener/LinxLinuxTcpListener.cpp
 
 HW_RPI2B = -DLINX_DEVICE_FAMILY=4 -DLINX_DEVICE_ID=3
+HW_RPI5 = -DLINX_DEVICE_FAMILY=4 -DLINX_DEVICE_ID=5
 HW_BBB = -DLINX_DEVICE_FAMILY=6 -DLINX_DEVICE_ID=1
 
 
-libs: raspberryPi2BLib beagleBoneBlackLib
+libs: raspberryPi2BLib raspberryPi5Lib beagleBoneBlackLib
 
-allio: beagleBoneBlackAll raspberryPi2BAll
+allio: beagleBoneBlackAll raspberryPi2BAll raspberryPi5All
 
 beagleBoneBlackAll: beagleBoneBlackSerial beagleBoneBlackTcp beagleBoneBlackConfigurable
 
 raspberryPi2BAll: raspberryPi2BSerial raspberryPi2BTcp raspberryPi2BConfigurable
-	
+
+raspberryPi5All: raspberryPi5Serial raspberryPi5Tcp raspberryPi5Configurable
+
 #----------------------- Shared Objects -----------------------
 raspberryPi2BLib:
 	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) -Wall -shared -fPIC -lrt -o ../core/examples/LinxDeviceLib/bin/liblinxdevice_rpi2.so ../core/examples/LinxDeviceLib/src/LinxDeviceLib.cpp $(CORE_RPI2) $(HW_RPI2B) -DLINXCONFIG -DDEBUG_ENABLED=-1 -g
+
+raspberryPi5Lib:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) -Wall -shared -fPIC -lrt -o ../core/examples/LinxDeviceLib/bin/liblinxdevice_rpi5.so ../core/examples/LinxDeviceLib/src/LinxDeviceLib.cpp $(CORE_RPI5) $(HW_RPI5) -DLINXCONFIG -DDEBUG_ENABLED=-1 -g
 
 beagleBoneBlackLib:
 	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) -Wall -shared -fPIC -lrt -o ../core/examples/LinxDeviceLib/bin/liblinxdevice_bbb.so ../core/examples/LinxDeviceLib/src/LinxDeviceLib.cpp $(CORE_BBB) $(HW_BBB) -DLINXCONFIG -DDEBUG_ENABLED=-1 -g
@@ -48,7 +55,16 @@ raspberryPi2BTcp:
 
 raspberryPi2BConfigurable:
 	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../core/examples/RaspberryPi_2_B_Configurable/src/RaspberryPi_2_B_Configurable.cpp $(CORE_RPI2) $(LISTENER_CONFIG) -lrt -DLINXCONFIG -DDEBUG_ENABLED=-1 -o ../core/examples/RaspberryPi_2_B_Configurable/bin/raspberryPi2BConfigurable.out
+
+raspberryPi5Serial:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../core/examples/RaspberryPi_5_Serial/src/RaspberryPi_5_Serial.cpp $(CORE_RPI5) $(LISTENER_SERIAL) -lrt -DLINXCONFIG -DDEBUG_ENABLED=-1 -o ../core/examples/RaspberryPi_5_Serial/bin/raspberryPi5Serial.out
 	
+raspberryPi5Tcp:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../core/examples/RaspberryPi_5_Tcp/src/RaspberryPi_5_Tcp.cpp $(CORE_RPI5) $(LISTENER_TCP) -lrt -DLINXCONFIG -DDEBUG_ENABLED=-1 -o ../core/examples/RaspberryPi_5_Tcp/bin/raspberryPi5Tcp.out
+
+raspberryPi5Configurable:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../core/examples/RaspberryPi_5_Configurable/src/RaspberryPi_5_Configurable.cpp $(CORE_RPI5) $(LISTENER_CONFIG) -lrt -DLINXCONFIG -DDEBUG_ENABLED=-1 -o ../core/examples/RaspberryPi_5_Configurable/bin/raspberryPi5Configurable.out
+
 #----------------------- Tests -----------------------
 tests: dio-test i2c-test spi-test
 
@@ -63,7 +79,16 @@ rpi2UartTest:
 	
 rpi2SpiTest:
 	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) -g $(INC) ../tests/src/rpi2/rpi2SpiTest.cpp $(CORE_RPI2) -lrt -DLINXCONFIG -DDEBUG_ENABLED=0 -o ../tests/bin/rpi2/spiTest.out
+
+rpi5DioTest:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../tests/src/rpi5/rpi5DioTest.cpp $(CORE_RPI5) -lrt -DLINXCONFIG -DDEBUG_ENABLED=0 -o ../tests/bin/rpi5/dioTest.out
 	
+rpi5UartTest:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../tests/src/rpi5/rpi5UartTest.cpp $(CORE_RPI5) -lrt -DLINXCONFIG -DDEBUG_ENABLED=-1 -o ../tests/bin/rpi5/uartTest.out
+	
+rpi5SpiTest:
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) -g $(INC) ../tests/src/rpi5/rpi5SpiTest.cpp $(CORE_RPI5) -lrt -DLINXCONFIG -DDEBUG_ENABLED=0 -o ../tests/bin/rpi5/spiTest.out
+
 i2c-test:
 	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) $(INC) ../tests/src/i2c-test.cpp $(CORE_BBB) -lrt -DLINXCONFIG -DDEBUG_ENABLED=0 -o ../tests/bin/i2ctest.out
 
@@ -132,4 +157,3 @@ cleanall:
 	rm -rf *.o
 	rm -rf *.out
 	rm -rf ../bin/*
-

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5DioTest.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5DioTest.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdlib.h> 
+#include <fstream>
+#include <termios.h>	
+#include <sstream>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <map>
+
+
+using namespace std;
+
+
+LinxRaspberryPi5* LinxDev;
+
+int main()
+{
+	LinxDev = new LinxRaspberryPi5();
+	cout << "\r\n.: DIO Test :.\r\n\r\n";
+	
+	LinxDev->DebugPrintln("Hello World!");
+	
+	unsigned char chan[1] = {7};
+	unsigned char onVal[1] = {0xFF};
+	unsigned char offVal[1] = {0x00};
+	
+	for(int i=0; i<3; i++)
+	{
+		LinxDev->DigitalWrite(1, chan, onVal);
+		usleep(500000);
+		LinxDev->DigitalWrite(1, chan, offVal);
+		usleep(500000);
+	}
+
+	
+}

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5SpiTest.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5SpiTest.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdlib.h> 
+#include <fstream>
+#include <termios.h>	
+#include <sstream>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <map>
+
+
+using namespace std;
+
+
+LinxRaspberryPi5* LinxDev;
+
+int main()
+{
+	LinxDev = new LinxRaspberryPi5();
+	cout << "\r\n.: SPI Test :.\r\n\r\n";
+	
+	//LinxDev->DigitalWrite(7, 0xFF);
+	
+	
+	//Open SPI Master
+	unsigned char spiChannel = 0;
+	unsigned char frameSize = 4;
+	unsigned char numFrames = 2;
+	unsigned char csChan = 7;
+	unsigned char csLL = 0;	//Active Low
+	unsigned char sendBuffer[8] = {0xAA, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+	unsigned char receiveBuffer[32]; 
+	
+	LinxDev->SpiOpenMaster(spiChannel);
+	fprintf(stdout, "SPI %d open.\n", spiChannel);
+	
+	//Transfer Data
+	int iterations = 10;
+	for(int i=0; i<iterations; i++)
+	{
+		LinxDev->SpiWriteRead(spiChannel, frameSize, numFrames, csChan, csLL, sendBuffer, receiveBuffer);
+		//receiveBuffer[frameSize*numFrames] = 0;
+		//fprintf(stdout, "Write/Read Complete: %s\n", receiveBuffer);
+		
+		for(int i=0; i< frameSize*numFrames; i++)
+		{
+			LinxDev->DebugPrint("[0x");
+			LinxDev->DebugPrint(receiveBuffer[i], HEX);
+			LinxDev->DebugPrint("] ");
+		}
+		LinxDev->DebugPrintln("");
+	}
+	
+}
+	
+	

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5UartTest.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/tests/src/rpi5/rpi5UartTest.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+
+#include "LinxDevice.h"
+#include "LinxRaspberryPi.h"
+#include "LinxRaspberryPi5.h"
+
+#include <stdio.h>
+#include <fcntl.h>
+#include <time.h>
+#include <unistd.h>
+#include <stdlib.h> 
+#include <fstream>
+#include <termios.h>	
+#include <sstream>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <map>
+
+
+using namespace std;
+
+
+LinxRaspberryPi5* LinxDev;
+
+int main()
+{
+	cout << "\r\n.: Raspberry Pi 5 UART Test :.\r\n\r\n";
+	
+	LinxDev = new LinxRaspberryPi5();
+	
+	unsigned long actualBaud = 0;
+	unsigned char uartChan = 0;
+	
+	//Data
+	unsigned char txbuffer[64] = "Hello World!";	
+	unsigned char rxbuffer[64];
+	unsigned char numBytesTx = 12;
+	unsigned char numBytesRx = 0;
+	
+	cout << "Opening UART\r\n";
+	LinxDev->UartOpen(uartChan, 115200, &actualBaud);
+	
+	unsigned char bytesAtPort = 0;
+	while(1)
+	{
+		if(LinxDev->UartGetBytesAvailable(uartChan, &bytesAtPort) == LUART_AVAILABLE_FAIL)
+		{
+			cout << "Fail\n";
+		}
+		//cout << (unsigned int)bytesAtPort << " Bytes Available\n";
+	}
+	
+	/*
+	cout << "Writing Data\r\n";	
+	LinxDev->UartWrite(uartChan, numBytesTx, txbuffer);
+	
+	cout << "Reading Data\r\n";
+	LinxDev->UartRead(uartChan, numBytesTx, rxbuffer, &numBytesRx);
+	
+	
+	if(numBytesRx != numBytesTx)
+	{
+		fprintf(stdout, "\r\nFail - Sent %d bytes but read %d bytes.\r\n\r\n", numBytesTx, numBytesRx);
+	}
+	else
+	{
+		rxbuffer[numBytesTx] = 0;
+		fprintf(stdout, "\r\nSuccess - '");
+		fprintf(stdout, "%s", rxbuffer);
+		fprintf(stdout, "'\r\n\r\n");
+		
+	}	
+	
+	*/
+	
+	cout << "Closing UART\r\n";
+	LinxDev->UartClose(uartChan);
+	
+	
+	
+	return 0;
+
+
+	
+}


### PR DESCRIPTION
The GPIO sysfs etries changed significantly compared to previous RPi's. Create a new LINX device to handle the changes.

Testing is still in progress.
