### PR TITLE
Fix DIO crash on RPi5

### DIFF
--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.cpp
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.cpp
@@ -33,7 +33,7 @@ const unsigned char LinxRaspberryPi2B::m_DeviceName[DEVICE_NAME_LEN] = "Raspberr
 
 //DIGITAL
 const unsigned char LinxRaspberryPi2B::m_DigitalChans[NUM_DIGITAL_CHANS] = {7, 11, 12, 13, 15, 16, 18, 22, 29, 31, 32, 33, 35, 36, 37, 38, 40};
-const unsigned char LinxRaspberryPi2B::m_gpioChan[NUM_DIGITAL_CHANS] =     {4, 17, 18, 27, 22, 23, 24, 25, 5, 6, 12, 13, 19, 16, 26, 20, 21};
+const unsigned int LinxRaspberryPi2B::m_gpioChan[NUM_DIGITAL_CHANS] =     {4, 17, 18, 27, 22, 23, 24, 25, 5, 6, 12, 13, 19, 16, 26, 20, 21};
 
 //PWM
 //None

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.h
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/LinxRaspberryPi2B.h
@@ -68,7 +68,7 @@ class LinxRaspberryPi2B : public LinxRaspberryPi
 		
 		//DIGITAL
 		static const unsigned char m_DigitalChans[NUM_DIGITAL_CHANS];
-		static const unsigned char m_gpioChan[NUM_DIGITAL_CHANS];
+		static const unsigned int m_gpioChan[NUM_DIGITAL_CHANS];
 		
 		//PWM
 		//None

--- a/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/utility/LinxRaspberryPi.h
+++ b/LabVIEW/vi.lib/MakerHub/LINX/Firmware/Source/core/device/utility/LinxRaspberryPi.h
@@ -36,7 +36,7 @@ class LinxRaspberryPi : public LinxDevice
 		**  Variables
 		****************************************************************************************/
 		//DIO
-		map<unsigned char, unsigned char> DigitalChannels;				//Maps LINX DIO Channel Numbers To BB GPIO Channels
+		map<unsigned char, unsigned int> DigitalChannels;				//Maps LINX DIO Channel Numbers To BB GPIO Channels
 		map<unsigned char, unsigned char> DigitalDirs;						//Current DIO Direction Values
 		map<unsigned char, FILE*> DigitalDirHandles;							//File Handles For Digital Pin Directions
 		map<unsigned char, FILE*> DigitalValueHandles;						//File Handles For Digital Pin Values


### PR DESCRIPTION
### What does this Pull Request accomplish?

The GPIO channel number was being truncated because of an incorrect data type, which later lead to a crash.  Fix the data type; fix the crash.

### What testing has been done?

Tested on Raspberry Pi 5
